### PR TITLE
Fix invalid URL errors that prevent loading more than 2 pages

### DIFF
--- a/manga-loader.user.js
+++ b/manga-loader.user.js
@@ -1358,7 +1358,11 @@ var extractInfo = function(selector, mod, context) {
       case 'a':
         if(mod.type === 'index')
           return parseInt(elem.textContent);
-        return elem.href || elem.getAttribute('href');
+        var href = elem.href || elem.getAttribute('href');
+        if (!href.startsWith('//') && !href.startsWith('http') && !href.startsWith('#')) {
+          return window.location.href + "/../" + href;
+        }
+        return href;
       case 'ul':
         return elem.children.length;
       case 'select':


### PR DESCRIPTION
Manga Loader on Mangafox on Firefox failed to load more than 2 pages, since it attempted to load `3.html` which is not a valid URL. This commit patches it.