### PR TITLE
add support for mangafox mirror (fanfox.net)

### DIFF
--- a/manga-loader.user.js
+++ b/manga-loader.user.js
@@ -11,6 +11,7 @@
 // @match *://bato.to/reader*
 // @match *://mangafox.me/manga/*/*/*
 // @match *://mangafox.la/manga/*/*/*
+// @match *://fanfox.net/manga/*/*/*
 // @match *://readms.net/r/*/*
 // @match *://readms.net/read/*/*
 // @match *://mangastream.com/r/*/*/*/*
@@ -220,7 +221,7 @@ var implementations = [{
   prevchap: '#mangainfofooter > #mangainfo_bas table tr:last-child a'
 }, {
   name: 'mangafox',
-  match: "^https?://mangafox.(me|la)/manga/[^/]*/[^/]*/[^/]*",
+  match: "^https?://(fan|manga)fox.(me|la|net)/manga/[^/]*/[^/]*/[^/]*",
   img: '.read_img img',
   next: '.read_img a',
   numpages: function() {


### PR DESCRIPTION
The owners of mangafox have seemingly decided in their infinite wisdom to create ANOTHER site just an hr or so ago. This time it's called `fanfox.net`.

Aside from annoying the crap out of me due to them again reuploading every damn manga and spamming the rss feed with 500 something notifications within the hr, I suspect there's a chance that this might be in prep for another domain move, which if so, this script change will enable both domains to be supported, for a smoother transition for users. 

I sincerely hope they stop moving domains.