### PR TITLE
Fixed the issue Mangafox is having with missing zeros

### DIFF
--- a/manga-loader.user.js
+++ b/manga-loader.user.js
@@ -243,7 +243,7 @@ var implementations = [{
   numpages: function() {
     _fix = '0000000000';
     // This block is used to add zeros to the URL of the first page to load if necessary
-    if (extractInfo('.read_img') == null) {
+    if (extractInfo('.read_img') == null && !location.href.includes(_fix)) {
       location.href = location.href.replace(/\/([^\/]*)$/,'\/' + _fix + '$1');
     }
     return extractInfo('select.m') - 1;

--- a/manga-loader.user.js
+++ b/manga-loader.user.js
@@ -242,8 +242,8 @@ var implementations = [{
   },
   numpages: function() {
     _fix = '0000000000';
-    // This block is used to add zeros to the URL of the first page to load
-    if (!location.href.match('\/' + _fix + '[^\/]*$')) {
+    // This block is used to add zeros to the URL of the first page to load if necessary
+    if (extractInfo('.read_img') == null) {
       location.href = location.href.replace(/\/([^\/]*)$/,'\/' + _fix + '$1');
     }
     return extractInfo('select.m') - 1;

--- a/manga-loader.user.js
+++ b/manga-loader.user.js
@@ -242,9 +242,13 @@ var implementations = [{
   },
   numpages: function() {
     _fix = '0000000000';
-    // This block is used to add zeros to the URL of the first page to load if necessary
-    if (extractInfo('.read_img') == null && !location.href.includes(_fix)) {
-      location.href = location.href.replace(/\/([^\/]*)$/,'\/' + _fix + '$1');
+    // This block is used to solve issues with the URL of the first page to load if necessary
+    if (extractInfo('.read_img') == null) {
+      if (!location.href.includes('.html')) { // In case the page only shows comments
+        location.href = location.href + '1.html';
+      } else if (!location.href.includes(_fix)) { // In case the page misses zeros
+        location.href = location.href.replace(/\/([^\/]*)$/,'\/' + _fix + '$1');
+      }
     }
     return extractInfo('select.m') - 1;
   },

--- a/manga-loader.user.js
+++ b/manga-loader.user.js
@@ -146,6 +146,9 @@ var reuse = {
   }
 };
 
+// string used to solve the issue Mangafox is having when the URL is missing zeros
+var mangafoxFix = '0000000000';
+
 /**
 Sample Implementation:
 {
@@ -2114,6 +2117,10 @@ var loadManga = function(imp) {
         }
       },
       loadNextPage = function(url) {
+        // Fix used to solve the issue Mangafox is having when the URL is missing zeros
+        if (imp.name == 'mangafox') {
+          url = url.replace(/\/([^\/]*)$/,'\/' + mangafoxFix + '$1');
+        }
         if (mLoadNum !== 'all' && count % mLoadNum === 0) {
           if (resumeUrl) {
             resumeUrl = null;
@@ -2217,6 +2224,10 @@ var waitAndLoad = function(imp) {
 var MLoaderLoadImps = function(imps) {
   var success = imps.some(function(imp) {
     if (imp.match && (new RegExp(imp.match, 'i')).test(pageUrl)) {
+      // Fix used to solve the issue Mangafox is having when the URL is missing zeros
+      if (imp.name == 'mangafox' && !location.href.match('\/' + mangafoxFix + '[^\/]*$')) {
+        location.href = location.href.replace(/\/([^\/]*)$/,'\/' + mangafoxFix + '$1');
+      }    
       currentImpName = imp.name;
       if (W.BM_MODE || (autoload !== 'no' && (mAutoload || autoload))) {
         log('autoloading...');


### PR DESCRIPTION
For some time now, Mangafox has been having a strange issue where pages would sometimes not load if the URL doesn't contain a certain number of 0s.
Usually, adding a single 0 is enough, but in some cases several are needed...

Let's take this page for example:
http://fanfox.net/manga/lv_999_no_murabito_novel/c008/1.html

The image won't be displayed unless the URL has at least 3 zeros, like so:
http://fanfox.net/manga/lv_999_no_murabito_novel/c008/0001.html

The second page of the chapter also needs 2 zeros to work:
http://fanfox.net/manga/lv_999_no_murabito_novel/c008/002.html

This pull request contains a quick fix to solve this issue, simply adding 10 zeros to every page from Mangafox...
I wasn't sure of where to implement it though, so if there is any issue with the way I handle things please feel free to tell me.