### PR TITLE
put image and counter into one div container

### DIFF
--- a/manga-loader.user.js
+++ b/manga-loader.user.js
@@ -2142,8 +2142,11 @@ var addImage = function(src, loc, imgNum, callback) {
   image.id = 'ml-pageid-' + imgNum;
   image.onload = callback;
   image.src = src;
-  loc.appendChild(image);
-  loc.appendChild(counter);
+  var imgwithcounter = document.createElement('div');
+  imgwithcounter.id = 'page-' + imgNum;
+  loc.appendChild(imgwithcounter);
+  imgwithcounter.appendChild(image);
+  imgwithcounter.appendChild(counter);
 };
 
 var loadManga = function(imp) {

--- a/manga-loader.user.js
+++ b/manga-loader.user.js
@@ -1802,7 +1802,7 @@ var getViewer = function(prevChapter, nextChapter) {
       var target = e.target;
       UI.images.removeEventListener('click', imgClick, false);
       UI.images.style.cursor = '';
-      if(target.nodeName === 'IMG' && target.parentNode.className === 'ml-images') {
+      if(target.nodeName === 'IMG') {
         showFloatingMsg('');
         if(!target.title) {
           showFloatingMsg('Reloading "' + target.src + '"', 3000);


### PR DESCRIPTION
before:
<img width="549" alt="21：53：51" src="https://user-images.githubusercontent.com/74352334/146643564-228bdb6f-2359-4cb0-982e-45dc55602c85.png">
after:
<img width="546" alt="21：47：55" src="https://user-images.githubusercontent.com/74352334/146643578-a7488987-35f5-4836-a793-74b6e07e1152.png">
This makes it easier to manipulate images with css.

For example, we can use flex container to make the manga display in 2 columns with this css applied:
```
.ml-images{
 display: inline-flex;
 align-content: flex-start;
 flex-flow: row wrap;
}
.ml-images>div{
 box-sizing: border-box;
 flex: 0 0 50%;
}
```
but this css doesn't work with the original script, and only makes counter larger.